### PR TITLE
feat: Enable spellcheck by default

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -89,6 +89,7 @@ vim.opt.cursorline = false
 
 -- Minimal number of screen lines to keep above and below the cursor.
 vim.opt.scrolloff = 5
+vim.opt.spell = true
 
 -- [[ Basic Keymaps ]]
 --  See `:help vim.keymap.set()`


### PR DESCRIPTION
This change modifies the init.lua to set vim.opt.spell = true, enabling the spellcheck feature automatically when Neovim starts.