### PR TITLE
Refactor: Improve Neovim configuration and add spell checking

### DIFF
--- a/nvim/lua/kickstart/plugins/gitsigns.lua
+++ b/nvim/lua/kickstart/plugins/gitsigns.lua
@@ -6,6 +6,13 @@ return {
   {
     'lewis6991/gitsigns.nvim',
     opts = {
+      signs = {
+        add = { text = '+' },
+        change = { text = '~' },
+        delete = { text = '_' },
+        topdelete = { text = '‾' },
+        changedelete = { text = '~' },
+      },
       on_attach = function(bufnr)
         local gitsigns = require 'gitsigns'
 


### PR DESCRIPTION
This commit implements several improvements to the Neovim configuration based on a detailed analysis:

1.  **Enabled Automated Tool Installation:**
    *   Uncommented and configured `mason-tool-installer.nvim` in `init.lua` to automatically install essential formatters (`stylua`, `shfmt`, `prettier`, `markdownlint-cli`, `eslint_d`) and linters (`shellcheck`).

2.  **Completed Treesitter Parser List:**
    *   Expanded the `ensure_installed` list for `nvim-treesitter` in `init.lua` to include parsers for Python, JS/TS (jsx/tsx), Go, Rust, CSS, JSON, and YAML for a better out-of-the-box experience for you.

3.  **Consolidated `gitsigns.nvim` Configuration:**
    *   Moved all `gitsigns.nvim` options (sign characters and `on_attach` keymaps) into `lua/kickstart/plugins/gitsigns.lua`.
    *   Removed the redundant direct configuration from `init.lua`, relying on the `require` statement for loading.

4.  **Enabled Nerd Font Diagnostic Signs:**
    *   Uncommented the code in `init.lua` to display Nerd Font icons for diagnostics, as `vim.g.have_nerd_font` is enabled.

5.  **Corrected `vim.opt.showmode`:**
    *   Changed `vim.opt.showmode` to `false` in `init.lua` to align with comments, as the status line handles mode display.

6.  **Enabled Spell Checking by Default:**
    *   Added `vim.opt.spell = true` and `vim.opt.spelllang = 'en_us'` to `init.lua` to enable spell checking for US English by default.

These changes enhance the robustness, maintainability, and your experience of the Neovim setup by ensuring necessary tools and parsers are available automatically and by refining existing configurations.